### PR TITLE
Add RRSet support for wildcards

### DIFF
--- a/certbot_plugin_gandi/gandi_api.py
+++ b/certbot_plugin_gandi/gandi_api.py
@@ -56,6 +56,18 @@ def _get_relative_name(base_domain, name):
     return name[:-len(suffix)] if name.endswith(suffix) else None
 
 
+def _get_txt_record(cfg, base_domain, relative_name):
+    response = _request(cfg, 'GET', ['zones', base_domain.zone_uuid, 'records', relative_name, 'TXT'])
+    if not response.ok:
+        return []
+    zone = _get_json(response)
+    vals = zone.get('rrset_values')
+    if vals:
+        return vals
+    else:
+        return []
+
+
 def _del_txt_record(cfg, base_domain, relative_name):
     return _request(cfg, 'DELETE', ('zones', base_domain.zone_uuid, 'records', relative_name, 'TXT'))
 
@@ -77,10 +89,14 @@ def _update_record(cfg, domain, name, request_runner):
 def add_txt_record(cfg, domain, name, value):
 
     def requester(base_domain, relative_name):
-        _del_txt_record(cfg, base_domain, relative_name)
+        existing = _get_txt_record(cfg, base_domain, relative_name)
+        to_add = [value] + existing
+        if existing:
+            _del_txt_record(cfg, base_domain, relative_name)
+
         return _request(cfg, 'POST',
                         ('zones', base_domain.zone_uuid, 'records', relative_name, 'TXT'),
-                        json={'rrset_values': [value]})
+                        json={'rrset_values': to_add})
 
     return _update_record(cfg, domain, name, requester)
 


### PR DESCRIPTION
Previously, the plugin would blow away existing TXT records for the
same DNS name when adding a TXT record. This means that issuing a
certificate for both a base domain and its wildcard could not succeed.